### PR TITLE
Migrations class conflict with Cashier

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ php artisan vendor:publish --provider="Overtrue\\LaravelSubscribe\\SubscribeSe
 
 ### Migrations
 
-This step is also optional, if you want to custom subscriptions table, you can publish the migration files:
+**You need to publish the migration files for use the package:**
 
 ```php
 $ php artisan vendor:publish --provider="Overtrue\\LaravelSubscribe\\SubscribeServiceProvider" --tag=migrations

--- a/src/SubscribeServiceProvider.php
+++ b/src/SubscribeServiceProvider.php
@@ -30,10 +30,6 @@ class SubscribeServiceProvider extends ServiceProvider
         $this->publishes([
             \dirname(__DIR__) . '/migrations/' => database_path('migrations'),
         ], 'migrations');
-
-        if ($this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(\dirname(__DIR__) . '/migrations/');
-        }
     }
 
     /**

--- a/src/SubscribeServiceProvider.php
+++ b/src/SubscribeServiceProvider.php
@@ -14,7 +14,7 @@ namespace Overtrue\LaravelSubscribe;
 use Illuminate\Support\ServiceProvider;
 
 /**
- * Class LikeServiceProvider.
+ * Class SubscribeServiceProvider.
  */
 class SubscribeServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
The migrations of the package conflicts with Cashier.

So there's no way we can ignore them unless they don't autoload when we run migrate (this will need to explain that is mandatory to do the `vendor:publish` command first on install)